### PR TITLE
[feature/util-annotation-add] MultiFormFactorPreviews 추가

### DIFF
--- a/app/src/main/java/org/sopt/stamp/MainActivity.kt
+++ b/app/src/main/java/org/sopt/stamp/MainActivity.kt
@@ -2,9 +2,35 @@ package org.sopt.stamp
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import org.sopt.stamp.designsystem.style.SoptTheme
+import org.sopt.stamp.util.MultiFormFactorPreviews
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setContent {
+            SoptTheme {
+                Greeting()
+            }
+        }
+    }
+}
+
+@Composable
+private fun Greeting() {
+    Box {
+        Text("Hello World!")
+    }
+}
+
+@MultiFormFactorPreviews
+@Composable
+fun Preview() {
+    SoptTheme {
+        Greeting()
     }
 }

--- a/app/src/main/java/org/sopt/stamp/util/MultiFormFactorPreviews.kt
+++ b/app/src/main/java/org/sopt/stamp/util/MultiFormFactorPreviews.kt
@@ -1,0 +1,17 @@
+package org.sopt.stamp.util
+
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(
+    name = "phone",
+    device = "spec:shape=Normal,width=360,height=800,unit=dp,dpi=480",
+    showBackground = true,
+    showSystemUi = true
+)
+@Preview(
+    name = "tablet",
+    device = "spec:shape=Normal,width=1280,height=800,unit=dp,dpi=480",
+    showBackground = true,
+    showSystemUi = true
+)
+annotation class MultiFormFactorPreviews()


### PR DESCRIPTION
## What is this issue?
- [x] MultiFormFactorPreviews 추가


## Reference
<img width="510" alt="스크린샷 2022-11-24 오후 8 26 40" src="https://user-images.githubusercontent.com/54518925/203773109-2086445e-3ae5-4e0e-bc8f-286dead2194b.png">

이런식으로 Phone, Tablet 모든 화면에서 어떻게 보이는지 볼 수 있음. 만약에 높이 다른 device도 추가하고 싶으면 annotation 추가해도 됨
